### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.OfficeRunner.json
+++ b/org.gnome.OfficeRunner.json
@@ -16,10 +16,6 @@
         /* Play sounds */
         "--socket=pulseaudio"
     ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g"
-    },
     "modules": [
         {
             "name": "office-runner",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.